### PR TITLE
fixes issue with game not restarting

### DIFF
--- a/Assets/Scripts/FlagManager.cs
+++ b/Assets/Scripts/FlagManager.cs
@@ -9,7 +9,7 @@ public class FlagManager : MonoBehaviour
     private GameObject flagPrefab;
 
     private GameObject[] spawnLocations;
-    private List<GameObject> flags = new List<GameObject>();
+    private List<GameObject> flags;
 
     public int FlagsRemaining()
     {
@@ -22,8 +22,9 @@ public class FlagManager : MonoBehaviour
         Destroy(flag);
     }
 
-    private void Start()
+    public void SpawnFlags()
     {
+        flags = new List<GameObject>();
         spawnLocations = GameObject.FindGameObjectsWithTag("FlagSpawn");
         foreach (GameObject spawnLocation in spawnLocations)
         {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -19,6 +19,7 @@ public class GameManager : MonoBehaviour
     private GameObject[] spawnLocations;
     private string gameResult;
     private WaitForSeconds endWait;
+    private FlagManager flagManager;
 
     public void KillPlayer()
     {
@@ -44,6 +45,9 @@ public class GameManager : MonoBehaviour
         endWait = new WaitForSeconds(endDelay);
 
         SpawnPlayer();
+
+        flagManager = gameObject.GetComponent<FlagManager>();
+        flagManager.SpawnFlags();
 
         StartCoroutine(GameLoop());
     }
@@ -86,6 +90,7 @@ public class GameManager : MonoBehaviour
 
     private IEnumerator GamePlaying()
     {
+        yield return new WaitForSeconds(3.0f);
         while (FlagsRemaining() && LivesRemaining())
         {
             yield return null;
@@ -113,7 +118,6 @@ public class GameManager : MonoBehaviour
 
     private bool FlagsRemaining()
     {
-        FlagManager flagManager = gameObject.GetComponent<FlagManager>();
         return flagManager.FlagsRemaining() > 0;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -90,7 +90,6 @@ public class GameManager : MonoBehaviour
 
     private IEnumerator GamePlaying()
     {
-        yield return new WaitForSeconds(3.0f);
         while (FlagsRemaining() && LivesRemaining())
         {
             yield return null;


### PR DESCRIPTION
The issue was a race condition that for some reason only became apparent after the recent merge request.  The bug was that my game loop could start without the flags being spawned, exiting the loop early and ending the game but not restarting it because the flags would spawn before the next step.  

The fix was to let the game manager spawn the flags, instead of the start method on the flag manager.  This will ensure they are always there before the game manager begins checking.  